### PR TITLE
fix: thread 'main' panicked (awslabs/aws-lambda-rust-runtime#266)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ autobins = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "0.3.1", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "0.2", features = ["macros"] }
 lambda = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "master"}
 serde_json = "1.0"
 


### PR DESCRIPTION
https://github.com/awslabs/aws-lambda-rust-runtime/issues/266