### PR TITLE
example: serialize/deserialize FlightData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ Cargo.lock
 
 .DS_Store
 
-src/ops/test_output
+src/ops
 
 # Maven
 .classpath

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,6 +18,7 @@ base64 = "0.13"
 more-asserts = "0.2.1"
 arrow = { git = "https://github.com/DSLAM-UMD/arrow", branch = "scq" }
 datafusion = { git = "https://github.com/DSLAM-UMD/arrow", branch = "scq" }
+arrow-flight = { git = "https://github.com/DSLAM-UMD/arrow", branch = "scq" }
 typetag = "0.1"
 serde_traitobject = "0.2.7"
 serde_closure = "0.3.2"

--- a/src/legacy/ops/src/get_results.py
+++ b/src/legacy/ops/src/get_results.py
@@ -15,15 +15,31 @@
 
 from boto import kinesis
 import time
+import json
+import argparse
+
+parser = argparse.ArgumentParser(description='Get stream name.')
+parser.add_argument("-n", "--name", type=str, required=True)
+args = parser.parse_args()
+print("listening:", args.name)
 
 kinesis = kinesis.connect_to_region("us-east-1")
 shard_id = 'shardId-000000000000'  #we only have one shard!
-shard_it = kinesis.get_shard_iterator("joinResults", shard_id,
+
+shard_it = kinesis.get_shard_iterator("FlinkJoinResults", shard_id,
                                       "LATEST")["ShardIterator"]
-while 1 == 1:
+while 1:
     out = kinesis.get_records(shard_it, limit=1)
     if len(out["Records"]) != 0:
-        print(out["Records"][0]["Data"])
+        rec = json.loads(out["Records"][0]["Data"])
+        print(rec)
+
+        # if args.name=="joinResults":
+        #     if len(rec["results"]) != 0 :
+        #         print("Record num:", len(rec["results"]))
+        #         print(rec["results"])
+        # else:
+        #     print(rec)
 
     shard_it = out["NextShardIterator"]
     time.sleep(0.2)

--- a/src/legacy/ops/src/join_distributed.rs
+++ b/src/legacy/ops/src/join_distributed.rs
@@ -199,6 +199,10 @@ async fn handler(event: Value, _: Context) -> Result<(), Error> {
     let input: ProjectionOutputMsg = serde_json::from_value(event.clone()).unwrap();
     let mut join_output: Vec<HashMap<String, String>> = Vec::new();
     let batch_num = input.batch_num;
+    println!(
+        "batch num: {:?}, stream: {:?}, last batch? {:?}",
+        batch_num, input.stream_name, input.is_last
+    );
 
     BATCH_COMPLETENESS
         .lock()
@@ -308,13 +312,13 @@ async fn handler(event: Value, _: Context) -> Result<(), Error> {
     // let len1 = STREAM1_BATCHES.lock().unwrap()[&batch_num.clone()].len();
     // let len2 = STREAM2_BATCHES.lock().unwrap()[&batch_num.clone()].len();
 
-    // let res = JoinOutput {
-    //     results: join_output,
-    // };
-
-    let res = testMag {
-        msg: "test".to_string(),
+    let res = JoinOutput {
+        results: join_output,
     };
+
+    // let res = testMag {
+    //     msg: "test".to_string(),
+    // };
     // println!("{:}", json!(res));
     // Write to Kinesis Data streams
     let kinesis_client = KinesisClient::new(Region::UsEast1);

--- a/src/legacy/ops/src/lambda_check.rs
+++ b/src/legacy/ops/src/lambda_check.rs
@@ -87,7 +87,7 @@ async fn handler(event: Value, _: Context) -> Result<Value, Error> {
     match client.get_function_configuration(req).await {
         Ok(func) => {
             // Find function, invoke.
-            println!("{:#?}", func);
+            println!("Find func: {:?}", func_name);
             func_arn = func.function_arn.unwrap();
             let request = InvocationRequest {
                 function_name: func_name.clone(),
@@ -96,7 +96,7 @@ async fn handler(event: Value, _: Context) -> Result<Value, Error> {
                 ..InvocationRequest::default()
             };
             let result = client.invoke(request).await;
-            println!("result: {:#?}", result);
+            // println!("result: {:#?}", result);
         }
         Err(e) => {
             // Doesn't exist, create one.
@@ -113,7 +113,7 @@ async fn handler(event: Value, _: Context) -> Result<Value, Error> {
                     // println!("code info: {:?}", resp.configuration);
                     if let Some(code_location) = resp.code {
                         let url = code_location.location.unwrap();
-                        println!("code loacation: {:?}", url);
+                        // println!("code loacation: {:?}", url);
                         let https = HttpsConnector::new();
                         let codeClient = Client::builder().build::<_, hyper::Body>(https);
 
@@ -163,17 +163,16 @@ async fn handler(event: Value, _: Context) -> Result<Value, Error> {
     Ok(json!({ "msg": func_arn }))
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use std::fs::File;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
 
-//     #[tokio::test]
-//     async fn stream1() {
-//         let event: Value =
-//
-// serde_json::from_slice(include_bytes!("../test_output/proj_output_0.json"))
-//                 .expect("invalid kinesis event");
-//         handler(event, Context::default()).await.ok().unwrap();
-//     }
-// }
+    #[tokio::test]
+    async fn stream1() {
+        let event: Value =
+            serde_json::from_slice(include_bytes!("../test_output/proj_output_1.json"))
+                .expect("invalid kinesis event");
+        handler(event, Context::default()).await.ok().unwrap();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add an example of serialize and deserialize `FlightData` between lambda functions. 

`BatchRecord` structs need to be passed between lambda functions. However, arrow array data types (e.g: `PrimitiveArray<Int64>`) are not serializable. Arrow Flight provides the `FlightData` struct that can be converted to and from `BatchRecord`s and is also serializable. Therefore, we can pass `FlightData` between lambda functions.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
