### PR TITLE
example: physical plans to lambda functions

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -48,3 +48,19 @@ path = "sql/plan.rs"
 [[bin]]
 name = "serde"
 path = "sql/serde.rs"
+
+[[bin]]
+name = "mem_filter_lambda"
+path = "lambda/mem_filter_lambda.rs"
+
+[[bin]]
+name = "hash_agg1_lambda"
+path = "lambda/hash_agg1_lambda.rs"
+
+[[bin]]
+name = "hash_agg2_lambda"
+path = "lambda/hash_agg2_lambda.rs"
+
+[[bin]]
+name = "projection_lambda"
+path = "lambda/projection_lambda.rs"

--- a/examples/lambda/README.md
+++ b/examples/lambda/README.md
@@ -1,0 +1,40 @@
+### The SQL Statement
+
+```
+SELECT MAX(c1), MIN(c2), c3
+FROM aggregate_test_100
+WHERE c2 < 99
+GROUP BY c3
+```
+
+### Data
+
+```
+c1: [90, 100, 91, 101, 92, 102, 93, 103]
+c2: [92.1, 93.2, 95.3, 96.4, 98.5, 99.6, 100.7, 101.8]
+c3: ["a", "a", "a", "b", "b", "b", "c", "c"]
+```
+
+### Expected Output
+
+```
++---------+---------+----+
+| MAX(c1) | MIN(c2) | c3 |
++---------+---------+----+
+| 100     | 92.1    | a  |
+| 101     | 96.4    | b  |
++---------+---------+----+
+```
+
+### Plans Generated
+
+1. MemoryExec (Merged with FilterExec in this example)
+2. FilterExec (mem_filter_lambda.rs)
+3. CoalesceBatchesExec (Can be ignored)
+4. HashAggregateExec (hash_agg1_lambda.rs)
+5. HashAggregateExec (hash_agg2_lambda.rs)
+6. ProjectionExec (projection_lambda.rs)
+
+### Plan Details
+
+See plan_0.json

--- a/examples/lambda/hash_agg1_lambda.rs
+++ b/examples/lambda/hash_agg1_lambda.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2020 UMD Database Group. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrow::datatypes::{DataType, Schema};
+use arrow::record_batch::RecordBatch;
+use arrow_flight::FlightData;
+use datafusion::physical_plan::expressions::*;
+use datafusion::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
+use datafusion::physical_plan::memory::MemoryExec;
+use datafusion::physical_plan::{common, AggregateExpr, ExecutionPlan, PhysicalExpr};
+use lambda::{handler_fn, Context};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use arrow::util::pretty;
+
+type Error = Box<dyn std::error::Error + Sync + Send + 'static>;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Data {
+    data: String,
+    schema: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FlightDataRef {
+    #[serde(with = "serde_bytes")]
+    pub data_header: std::vec::Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub data_body: std::vec::Vec<u8>,
+}
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    lambda::run(handler_fn(handler)).await?;
+    Ok(())
+}
+
+async fn handler(event: Value, _: Context) -> Result<Value, Error> {
+    // Convert FlightData to BatchRecord
+    let input: Data = serde_json::from_value(event).unwrap();
+
+    let fake_flight_data: FlightDataRef = serde_json::from_str(&input.data).unwrap();
+    let prev_schema: Schema = serde_json::from_str(&input.schema).unwrap();
+
+    let flight_data_de = FlightData {
+        flight_descriptor: None,
+        app_metadata: vec![],
+        data_header: fake_flight_data.data_header,
+        data_body: fake_flight_data.data_body,
+    };
+    let arrow_batch = arrow_flight::utils::flight_data_to_arrow_batch(
+        &flight_data_de,
+        Arc::new(prev_schema.clone()),
+    )
+    .unwrap()?;
+
+    // Construct MemoryExec
+    let partitions: Vec<Vec<RecordBatch>> = vec![vec![arrow_batch]];
+    let mem_plan = MemoryExec::try_new(
+        &partitions,
+        Arc::new(prev_schema.clone()),
+        Some(vec![0, 1, 2]),
+    )?;
+
+    // Construct HashAggregateExec
+    let mode = AggregateMode::Partial;
+    let mut group_expr: Vec<(Arc<dyn PhysicalExpr>, String)> = Vec::new();
+    group_expr.push((Arc::new(Column::new("c3")), "c3".to_string()));
+
+    let mut aggr_expr: Vec<Arc<dyn AggregateExpr>> = Vec::new();
+    aggr_expr.push(Arc::new(Max::new(
+        Arc::new(Column::new("c1")),
+        "MAX(c1)".to_string(),
+        DataType::Int64,
+    )));
+    aggr_expr.push(Arc::new(Min::new(
+        Arc::new(Column::new("c2")),
+        "MIN(c2)".to_string(),
+        DataType::Float64,
+    )));
+
+    let plan = HashAggregateExec::try_new(mode, group_expr, aggr_expr, Arc::new(mem_plan))
+        .unwrap()
+        .execute(0)
+        .await?;
+    let output_schema = plan.schema();
+    let result = common::collect(plan).await?;
+    pretty::print_batches(&result)?;
+
+    // RecordBatch to FlightData
+    let options = arrow::ipc::writer::IpcWriteOptions::default();
+    let flight_data = &arrow_flight::utils::flight_data_from_arrow_batch(&result[0], &options)[0];
+
+    let flight_data_ref = FlightDataRef {
+        data_header: flight_data.data_header.clone(),
+        data_body: flight_data.data_body.clone(),
+    };
+    let data_str = serde_json::to_string(&flight_data_ref).unwrap();
+
+    Ok(json!({ "data": data_str, "schema": serde_json::to_string(&output_schema).unwrap()}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn handler_handles() {
+        let data = r#"{
+            "data": "{\"data_header\":[16,0,0,0,12,0,26,0,24,0,23,0,4,0,8,0,12,0,0,0,32,0,0,0,136,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,3,0,10,0,24,0,12,0,8,0,4,0,10,0,0,0,76,0,0,0,16,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,5,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,40,0,0,0,0,0,0,0,48,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,56,0,0,0,0,0,0,0,40,0,0,0,0,0,0,0,96,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,104,0,0,0,0,0,0,0,24,0,0,0,0,0,0,0,128,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0],\"data_body\":[255,0,0,0,0,0,0,0,90,0,0,0,0,0,0,0,100,0,0,0,0,0,0,0,91,0,0,0,0,0,0,0,101,0,0,0,0,0,0,0,92,0,0,0,0,0,0,0,255,0,0,0,0,0,0,0,102,102,102,102,102,6,87,64,205,204,204,204,204,76,87,64,51,51,51,51,51,211,87,64,154,153,153,153,153,25,88,64,0,0,0,0,0,160,88,64,255,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,2,0,0,0,3,0,0,0,4,0,0,0,5,0,0,0,97,97,97,98,98,0,0,0]}",
+            "schema": "{\"fields\":[{\"name\":\"c1\",\"data_type\":\"Int64\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false},{\"name\":\"c2\",\"data_type\":\"Float64\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false},{\"name\":\"c3\",\"data_type\":\"Utf8\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false}]}"
+        }"#;
+        let event: Value = serde_json::from_str(data).unwrap();
+        handler(event, Context::default()).await.ok().unwrap();
+    }
+}

--- a/examples/lambda/hash_agg2_lambda.rs
+++ b/examples/lambda/hash_agg2_lambda.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2020 UMD Database Group. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrow::datatypes::{DataType, Schema};
+use arrow::record_batch::RecordBatch;
+use arrow_flight::FlightData;
+use datafusion::physical_plan::expressions::*;
+use datafusion::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
+use datafusion::physical_plan::memory::MemoryExec;
+use datafusion::physical_plan::{common, AggregateExpr, ExecutionPlan, PhysicalExpr};
+use lambda::{handler_fn, Context};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use arrow::util::pretty;
+
+type Error = Box<dyn std::error::Error + Sync + Send + 'static>;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Data {
+    data: String,
+    schema: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FlightDataRef {
+    #[serde(with = "serde_bytes")]
+    pub data_header: std::vec::Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub data_body: std::vec::Vec<u8>,
+}
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    lambda::run(handler_fn(handler)).await?;
+    Ok(())
+}
+
+async fn handler(event: Value, _: Context) -> Result<Value, Error> {
+    // Convert FlightData to BatchRecord
+    let input: Data = serde_json::from_value(event).unwrap();
+
+    let fake_flight_data: FlightDataRef = serde_json::from_str(&input.data).unwrap();
+    let prev_schema: Schema = serde_json::from_str(&input.schema).unwrap();
+
+    let flight_data_de = FlightData {
+        flight_descriptor: None,
+        app_metadata: vec![],
+        data_header: fake_flight_data.data_header,
+        data_body: fake_flight_data.data_body,
+    };
+    let arrow_batch = arrow_flight::utils::flight_data_to_arrow_batch(
+        &flight_data_de,
+        Arc::new(prev_schema.clone()),
+    )
+    .unwrap()?;
+
+    // Construct MemoryExec
+    let partitions: Vec<Vec<RecordBatch>> = vec![vec![arrow_batch]];
+    let mem_plan = MemoryExec::try_new(
+        &partitions,
+        Arc::new(prev_schema.clone()),
+        Some(vec![0, 1, 2]),
+    )?;
+
+    // Construct HashAggregateExec
+    let mode = AggregateMode::Final;
+    let mut group_expr: Vec<(Arc<dyn PhysicalExpr>, String)> = Vec::new();
+    group_expr.push((Arc::new(Column::new("c3")), "c3".to_string()));
+
+    let mut aggr_expr: Vec<Arc<dyn AggregateExpr>> = Vec::new();
+    aggr_expr.push(Arc::new(Max::new(
+        Arc::new(Column::new("c1")),
+        "MAX(c1)".to_string(),
+        DataType::Int64,
+    )));
+    aggr_expr.push(Arc::new(Min::new(
+        Arc::new(Column::new("c2")),
+        "MIN(c2)".to_string(),
+        DataType::Float64,
+    )));
+
+    let plan = HashAggregateExec::try_new(mode, group_expr, aggr_expr, Arc::new(mem_plan))
+        .unwrap()
+        .execute(0)
+        .await?;
+    let output_schema = plan.schema();
+
+    let result = common::collect(plan).await?;
+    pretty::print_batches(&result)?;
+
+    // RecordBatch to FlightData
+    let options = arrow::ipc::writer::IpcWriteOptions::default();
+    let flight_data = &arrow_flight::utils::flight_data_from_arrow_batch(&result[0], &options)[0];
+
+    let flight_data_ref = FlightDataRef {
+        data_header: flight_data.data_header.clone(),
+        data_body: flight_data.data_body.clone(),
+    };
+    let data_str = serde_json::to_string(&flight_data_ref).unwrap();
+
+    Ok(json!({ "data": data_str, "schema": serde_json::to_string(&output_schema).unwrap()}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn handler_handles() {
+        let data = r#"{
+            "data": "{\"data_header\":[16,0,0,0,12,0,26,0,24,0,23,0,4,0,8,0,12,0,0,0,32,0,0,0,80,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,3,0,10,0,24,0,12,0,8,0,4,0,10,0,0,0,76,0,0,0,16,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,24,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,32,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,40,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,56,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,64,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0],\"data_body\":[255,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,2,0,0,0,0,0,0,0,98,97,0,0,0,0,0,0,255,0,0,0,0,0,0,0,101,0,0,0,0,0,0,0,100,0,0,0,0,0,0,0,255,0,0,0,0,0,0,0,154,153,153,153,153,25,88,64,102,102,102,102,102,6,87,64]}",
+            "schema": "{\"fields\":[{\"name\":\"c3\",\"data_type\":\"Utf8\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false},{\"name\":\"MAX(c1)[max]\",\"data_type\":\"Int64\",\"nullable\":true,\"dict_id\":0,\"dict_is_ordered\":false},{\"name\":\"MIN(c2)[min]\",\"data_type\":\"Float64\",\"nullable\":true,\"dict_id\":0,\"dict_is_ordered\":false}]}"
+        }"#;
+        let event: Value = serde_json::from_str(data).unwrap();
+        handler(event, Context::default()).await.ok().unwrap();
+    }
+}

--- a/examples/lambda/mem_filter_lambda.rs
+++ b/examples/lambda/mem_filter_lambda.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2020 UMD Database Group. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrow::datatypes::{DataType, Schema};
+use arrow::json;
+use arrow::record_batch::RecordBatch;
+
+use datafusion::logical_plan::Operator;
+use datafusion::physical_plan::common;
+use datafusion::physical_plan::expressions::*;
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::memory::MemoryExec;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::scalar::ScalarValue;
+
+use arrow::util::pretty;
+use lambda::{handler_fn, Context};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use std::io::BufReader;
+
+type Error = Box<dyn std::error::Error + Sync + Send + 'static>;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Data {
+    data: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FlightDataRef {
+    #[serde(with = "serde_bytes")]
+    pub data_header: std::vec::Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub data_body: std::vec::Vec<u8>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    lambda::run(handler_fn(handler)).await?;
+    Ok(())
+}
+
+async fn handler(event: Value, _: Context) -> Result<Value, Error> {
+    // Construct BatchRecord
+    let input: Data = serde_json::from_value(event).unwrap();
+    let schema_str = "{\"fields\":[{\"name\":\"c1\",\"data_type\":\"Int64\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false},{\"name\":\"c2\",\"data_type\":\"Float64\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false},{\"name\":\"c3\",\"data_type\":\"Utf8\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false}]}";
+    let schema: Arc<Schema> = serde_json::from_str(schema_str).unwrap();
+
+    let data_str = input.data;
+    let reader = BufReader::new(data_str.as_bytes());
+    let mut json = json::Reader::new(reader, schema.clone(), 1024, None);
+    let record_batch: RecordBatch = json.next().unwrap().unwrap();
+    // println!("batch:\n{:?}", record_batch);
+
+    // Construct MemoryExec
+    let partitions: Vec<Vec<RecordBatch>> = vec![vec![record_batch.clone()]];
+    let mem_plan = MemoryExec::try_new(&partitions, schema.clone(), None)?;
+
+    // Construct FilterExec
+    let predicate: Arc<BinaryExpr> = Arc::new(BinaryExpr::new(
+        Arc::new(Column::new("c2")),
+        Operator::Lt,
+        Arc::new(CastExpr::new(
+            Arc::new(Literal::new(ScalarValue::Int64(Some(99)))),
+            DataType::Float64,
+        )),
+    ));
+
+    let plan = FilterExec::try_new(predicate, Arc::new(mem_plan))
+        .unwrap()
+        .execute(0)
+        .await?;
+    let result = common::collect(plan).await?;
+    pretty::print_batches(&result)?;
+
+    // RecordBatch to FlightData
+    let options = arrow::ipc::writer::IpcWriteOptions::default();
+    let flight_data = &arrow_flight::utils::flight_data_from_arrow_batch(&result[0], &options)[0];
+
+    let flight_data_ref = FlightDataRef {
+        data_header: flight_data.data_header.clone(),
+        data_body: flight_data.data_body.clone(),
+    };
+    let data_str = serde_json::to_string(&flight_data_ref).unwrap();
+
+    Ok(json!({ "data": data_str, "schema": schema_str.to_string()}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn filter_test() {
+        let data = r#"{"data": "{\"c1\": 90, \"c2\": 92.1, \"c3\": \"a\"}\n{\"c1\": 100, \"c2\": 93.2, \"c3\": \"a\"}\n{\"c1\": 91, \"c2\": 95.3, \"c3\": \"a\"}\n{\"c1\": 101, \"c2\": 96.4, \"c3\": \"b\"}\n{\"c1\": 92, \"c2\": 98.5, \"c3\": \"b\"}\n{\"c1\": 102, \"c2\": 99.6, \"c3\": \"b\"}\n{\"c1\": 93, \"c2\": 100.7, \"c3\": \"c\"}\n{\"c1\": 103, \"c2\": 101.8, \"c3\": \"c\"}"}"#;
+        let event: Value = serde_json::from_str(data).unwrap();
+
+        handler(event, Context::default()).await.ok().unwrap();
+    }
+}

--- a/examples/lambda/plan_0.json
+++ b/examples/lambda/plan_0.json
@@ -1,0 +1,277 @@
+ProjectionExec {
+    expr: [
+        (
+            Column {
+                name: "MAX(c1)",
+        },
+        "MAX(c1)",
+        ),
+        (
+            Column {
+                name: "MIN(c2)",
+        },
+        "MIN(c2)",
+        ),
+        (
+            Column {
+                name: "c3",
+        },
+        "c3",
+        ),
+    ],
+    schema: Schema {
+        fields: [
+            Field {
+                name: "MAX(c1)",
+                data_type: Int64,
+                nullable: true,
+                dict_id: 0,
+                dict_is_ordered: false,
+            },
+            Field {
+                name: "MIN(c2)",
+                data_type: Float64,
+                nullable: true,
+                dict_id: 0,
+                dict_is_ordered: false,
+            },
+            Field {
+                name: "c3",
+                data_type: Utf8,
+                nullable: false,
+                dict_id: 0,
+                dict_is_ordered: false,
+            },
+        ],
+        metadata: {},
+    },
+    input: HashAggregateExec {
+        mode: Final,
+        group_expr: [
+            (
+                Column {
+                    name: "c3",
+            },
+            "c3",
+            ),
+        ],
+        aggr_expr: [
+            Max {
+                name: "MAX(c1)",
+                data_type: Int64,
+                nullable: true,
+                expr: Column {
+                    name: "c1",
+                },
+            },
+            Min {
+                name: "MIN(c2)",
+                data_type: Float64,
+                nullable: true,
+                expr: Column {
+                    name: "c2",
+                },
+            },
+        ],
+        input: HashAggregateExec {
+            mode: Partial,
+            group_expr: [
+                (
+                    Column {
+                        name: "c3",
+                },
+                "c3",
+                ),
+            ],
+            aggr_expr: [
+                Max {
+                    name: "MAX(c1)",
+                    data_type: Int64,
+                    nullable: true,
+                    expr: Column {
+                        name: "c1",
+                    },
+                },
+                Min {
+                    name: "MIN(c2)",
+                    data_type: Float64,
+                    nullable: true,
+                    expr: Column {
+                        name: "c2",
+                    },
+                },
+            ],
+            input: CoalesceBatchesExec {
+                input: FilterExec {
+                    predicate: BinaryExpr {
+                        left: Column {
+                            name: "c2",
+                        },
+                        op: Lt,
+                        right: CastExpr {
+                            expr: Literal {
+                                value: Int64(99),
+                            },
+                            cast_type: Float64,
+                        },
+                    },
+                    input: MemoryExec {
+                        partitions: [
+                            [
+                                RecordBatch {
+                                    schema: Schema {
+                                        fields: [
+                                            Field {
+                                                name: "c1",
+                                                data_type: Int64,
+                                                nullable: false,
+                                                dict_id: 0,
+                                                dict_is_ordered: false,
+                                            },
+                                            Field {
+                                                name: "c2",
+                                                data_type: Float64,
+                                                nullable: false,
+                                                dict_id: 0,
+                                                dict_is_ordered: false,
+                                            },
+                                            Field {
+                                                name: "c3",
+                                                data_type: Utf8,
+                                                nullable: false,
+                                                dict_id: 0,
+                                                dict_is_ordered: false,
+                                            },
+                                        ],
+                                        metadata: {},
+                                    },
+                                    columns: [
+                                        PrimitiveArray<Int64>
+                                        [
+                                            90,
+                                            100,
+                                            91,
+                                            101,
+                                            92,
+                                            102,
+                                            93,
+                                            103,
+                                        ],
+                                        PrimitiveArray<Float64>
+                                        [
+                                            92.1,
+                                            93.2,
+                                            95.3,
+                                            96.4,
+                                            98.5,
+                                            99.6,
+                                            100.7,
+                                            101.8,
+                                        ],
+                                        StringArray
+                                        [
+                                            "a",
+                                            "a",
+                                            "a",
+                                            "b",
+                                            "b",
+                                            "b",
+                                            "c",
+                                            "c",
+                                        ],
+                                    ],
+                                },
+                            ],
+                        ],
+                        schema: Schema {
+                            fields: [
+                                Field {
+                                    name: "c1",
+                                    data_type: Int64,
+                                    nullable: false,
+                                    dict_id: 0,
+                                    dict_is_ordered: false,
+                                },
+                                Field {
+                                    name: "c2",
+                                    data_type: Float64,
+                                    nullable: false,
+                                    dict_id: 0,
+                                    dict_is_ordered: false,
+                                },
+                                Field {
+                                    name: "c3",
+                                    data_type: Utf8,
+                                    nullable: false,
+                                    dict_id: 0,
+                                    dict_is_ordered: false,
+                                },
+                            ],
+                            metadata: {},
+                        },
+                        projection: Some(
+                            [
+                            0,
+                            1,
+                            2,
+                        ],
+                        ),
+                    },
+                },
+                target_batch_size: 16384,
+            },
+            schema: Schema {
+                fields: [
+                    Field {
+                        name: "c3",
+                        data_type: Utf8,
+                        nullable: false,
+                        dict_id: 0,
+                        dict_is_ordered: false,
+                    },
+                    Field {
+                        name: "MAX(c1)[max]",
+                        data_type: Int64,
+                        nullable: true,
+                        dict_id: 0,
+                        dict_is_ordered: false,
+                    },
+                    Field {
+                        name: "MIN(c2)[min]",
+                        data_type: Float64,
+                        nullable: true,
+                        dict_id: 0,
+                        dict_is_ordered: false,
+                    },
+                ],
+                metadata: {},
+            },
+        },
+        schema: Schema {
+            fields: [
+                Field {
+                    name: "c3",
+                    data_type: Utf8,
+                    nullable: false,
+                    dict_id: 0,
+                    dict_is_ordered: false,
+                },
+                Field {
+                    name: "MAX(c1)",
+                    data_type: Int64,
+                    nullable: true,
+                    dict_id: 0,
+                    dict_is_ordered: false,
+                },
+                Field {
+                    name: "MIN(c2)",
+                    data_type: Float64,
+                    nullable: true,
+                    dict_id: 0,
+                    dict_is_ordered: false,
+                },
+            ],
+            metadata: {},
+        },
+    },
+}

--- a/examples/lambda/projection_lambda.rs
+++ b/examples/lambda/projection_lambda.rs
@@ -1,0 +1,118 @@
+// Copyright (c) 2020 UMD Database Group. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
+use arrow_flight::FlightData;
+use datafusion::physical_plan::expressions::*;
+use datafusion::physical_plan::memory::MemoryExec;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::{common, ExecutionPlan, PhysicalExpr};
+use lambda::{handler_fn, Context};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use arrow::util::pretty;
+
+type Error = Box<dyn std::error::Error + Sync + Send + 'static>;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Data {
+    data: String,
+    schema: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FlightDataRef {
+    #[serde(with = "serde_bytes")]
+    pub data_header: std::vec::Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub data_body: std::vec::Vec<u8>,
+}
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    lambda::run(handler_fn(handler)).await?;
+    Ok(())
+}
+
+async fn handler(event: Value, _: Context) -> Result<Value, Error> {
+    // Convert FlightData to BatchRecord
+    let input: Data = serde_json::from_value(event).unwrap();
+
+    let fake_flight_data: FlightDataRef = serde_json::from_str(&input.data).unwrap();
+    let prev_schema: Schema = serde_json::from_str(&input.schema).unwrap();
+
+    let flight_data_de = FlightData {
+        flight_descriptor: None,
+        app_metadata: vec![],
+        data_header: fake_flight_data.data_header,
+        data_body: fake_flight_data.data_body,
+    };
+    let arrow_batch = arrow_flight::utils::flight_data_to_arrow_batch(
+        &flight_data_de,
+        Arc::new(prev_schema.clone()),
+    )
+    .unwrap()?;
+
+    // Construct MemoryExec
+    let partitions: Vec<Vec<RecordBatch>> = vec![vec![arrow_batch]];
+    let mem_plan = MemoryExec::try_new(
+        &partitions,
+        Arc::new(prev_schema.clone()),
+        Some(vec![0, 1, 2]),
+    )?;
+
+    // Construct ProjectionExec
+    let mut expr: Vec<(Arc<dyn PhysicalExpr>, String)> = Vec::new();
+    expr.push((Arc::new(Column::new("MAX(c1)")), "MAX(c1)".to_string()));
+    expr.push((Arc::new(Column::new("MIN(c2)")), "MIN(c2)".to_string()));
+    expr.push((Arc::new(Column::new("c3")), "c3".to_string()));
+
+    let plan = ProjectionExec::try_new(expr, Arc::new(mem_plan))
+        .unwrap()
+        .execute(0)
+        .await?;
+    let output_schema = plan.schema();
+
+    let result = common::collect(plan).await?;
+    pretty::print_batches(&result)?;
+
+    // RecordBatch to FlightData
+    let options = arrow::ipc::writer::IpcWriteOptions::default();
+    let flight_data = &arrow_flight::utils::flight_data_from_arrow_batch(&result[0], &options)[0];
+
+    let flight_data_ref = FlightDataRef {
+        data_header: flight_data.data_header.clone(),
+        data_body: flight_data.data_body.clone(),
+    };
+    let data_str = serde_json::to_string(&flight_data_ref).unwrap();
+
+    Ok(json!({ "data": data_str, "schema": serde_json::to_string(&output_schema).unwrap()}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn handler_handles() {
+        let data = r#"{
+            "data": "{\"data_header\":[16,0,0,0,12,0,26,0,24,0,23,0,4,0,8,0,12,0,0,0,32,0,0,0,80,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,3,0,10,0,24,0,12,0,8,0,4,0,10,0,0,0,76,0,0,0,16,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,24,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,32,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,40,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0,56,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,64,0,0,0,0,0,0,0,16,0,0,0,0,0,0,0],\"data_body\":[255,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,2,0,0,0,0,0,0,0,97,98,0,0,0,0,0,0,255,0,0,0,0,0,0,0,100,0,0,0,0,0,0,0,101,0,0,0,0,0,0,0,255,0,0,0,0,0,0,0,102,102,102,102,102,6,87,64,154,153,153,153,153,25,88,64]}",
+            "schema": "{\"fields\":[{\"name\":\"c3\",\"data_type\":\"Utf8\",\"nullable\":false,\"dict_id\":0,\"dict_is_ordered\":false},{\"name\":\"MAX(c1)\",\"data_type\":\"Int64\",\"nullable\":true,\"dict_id\":0,\"dict_is_ordered\":false},{\"name\":\"MIN(c2)\",\"data_type\":\"Float64\",\"nullable\":true,\"dict_id\":0,\"dict_is_ordered\":false}]}"
+        }"#;
+        let event: Value = serde_json::from_str(data).unwrap();
+        handler(event, Context::default()).await.ok().unwrap();
+    }
+}

--- a/examples/sql/serde.rs
+++ b/examples/sql/serde.rs
@@ -235,6 +235,10 @@ mod tests {
     use super::*;
     use arrow::array::*;
     use arrow::datatypes::{DataType, Field, Schema};
+<<<<<<< Updated upstream
+=======
+    use serde_json::json;
+>>>>>>> Stashed changes
     use std::any::Any;
     use std::fmt::Debug;
     use std::sync::Arc;
@@ -649,6 +653,7 @@ mod tests {
     }
 
     #[tokio::test]
+<<<<<<< Updated upstream
     async fn fetch_record_batch() -> Result<(), Error> {
         use arrow::json;
         use arrow::json::reader::infer_json_schema;
@@ -696,6 +701,15 @@ mod tests {
             pub data_header: std::vec::Vec<u8>,
             #[serde(with = "serde_bytes")]
             pub data_body:   std::vec::Vec<u8>,
+=======
+    // This test shows an example of conversion between FlightData and RecordBatch
+    async fn recordbatch_flightdata_conversion() -> Result<(), Error> {
+        #[derive(Deserialize, Serialize)]
+        // Partial FlightData defination
+        pub struct FlightDataDef {
+            pub data_header: std::vec::Vec<u8>,
+            pub data_body: std::vec::Vec<u8>,
+>>>>>>> Stashed changes
         }
 
         // lambda 1
@@ -704,7 +718,7 @@ mod tests {
             Field::new("c2", DataType::Float64, false),
             Field::new("c3", DataType::Utf8, false),
         ]));
-        let record_batch = RecordBatch::try_new(
+        let record_batch = arrow::record_batch::RecordBatch::try_new(
             schema.clone(),
             vec![
                 Arc::new(Int64Array::from(vec![90, 100, 91, 101, 92, 102, 93, 103])),
@@ -717,45 +731,30 @@ mod tests {
             ],
         )?;
 
-        let options = IpcWriteOptions::default();
-        let flight_data = &flight_data_from_arrow_batch(&record_batch, &options)[0];
+        let options = arrow::ipc::writer::IpcWriteOptions::default();
+        let flight_data =
+            &arrow_flight::utils::flight_data_from_arrow_batch(&record_batch, &options)[0];
+        let data_header = flight_data.data_header.clone();
+        let data_body = flight_data.data_body.clone();
 
-        let flight_data_ref = FlightDataRef {
-            data_header: flight_data.data_header.clone(),
-            data_body:   flight_data.data_body.clone(),
-        };
-        let json = serde_json::to_string(&flight_data_ref).unwrap();
-        assert_eq!(
-            r#"{"data_header":[16,0,0,0,12,0,26,0,24,0,23,0,4,0,8,0,12,0,0,0,32,0,0,0,200,0,0,0,0,0,0,0,0,0,0,0,0,0,0,3,3,0,10,0,24,0,12,0,8,0,4,0,10,0,0,0,76,0,0,0,16,0,0,0,8,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,7,0,0,0,0,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,64,0,0,0,0,0,0,0,72,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,80,0,0,0,0,0,0,0,64,0,0,0,0,0,0,0,144,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0,152,0,0,0,0,0,0,0,40,0,0,0,0,0,0,0,192,0,0,0,0,0,0,0,8,0,0,0,0,0,0,0],"data_body":[255,0,0,0,0,0,0,0,90,0,0,0,0,0,0,0,100,0,0,0,0,0,0,0,91,0,0,0,0,0,0,0,101,0,0,0,0,0,0,0,92,0,0,0,0,0,0,0,102,0,0,0,0,0,0,0,93,0,0,0,0,0,0,0,103,0,0,0,0,0,0,0,255,0,0,0,0,0,0,0,102,102,102,102,102,6,87,64,205,204,204,204,204,76,87,64,51,51,51,51,51,211,87,64,154,153,153,153,153,25,88,64,0,0,0,0,0,160,88,64,102,102,102,102,102,230,88,64,205,204,204,204,204,44,89,64,51,51,51,51,51,115,89,64,255,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,2,0,0,0,3,0,0,0,4,0,0,0,5,0,0,0,6,0,0,0,7,0,0,0,8,0,0,0,0,0,0,0,97,97,97,98,98,98,99,99]}"#,
-            json
-        );
+        let flight_data_json = json!(FlightDataDef {
+            data_header,
+            data_body
+        });
 
         // lambda 2
-        let fake_flight_data: FlightDataRef = serde_json::from_str(&json).unwrap();
-        let flight_data = arrow_flight::FlightData {
+        let fake_flight_data: FlightDataDef = serde_json::from_value(flight_data_json).unwrap();
+        // In `arrow_flight::utils::flight_data_from_arrow_batch`, `flight_descriptor`
+        // and `app_metadata` do not contain data
+        let flight_data_de = arrow_flight::FlightData {
             flight_descriptor: None,
-            app_metadata:      vec![],
-            data_header:       fake_flight_data.data_header,
-            data_body:         fake_flight_data.data_body,
+            app_metadata: vec![],
+            data_header: fake_flight_data.data_header,
+            data_body: fake_flight_data.data_body,
         };
-
-        let arrow_batch = flight_data_to_arrow_batch(&flight_data, schema).unwrap()?;
-        assert_eq!(8, arrow_batch.num_rows());
-        assert_eq!(3, arrow_batch.num_columns());
-        assert_eq!(
-            r#"c1: Int64, c2: Float64, c3: Utf8"#,
-            format!("{}", arrow_batch.schema())
-        );
-        assert_eq!(
-            "PrimitiveArray<Int64>\n[\n  90,\n  100,\n  91,\n  101,\n  92,\n  102,\n  93,\n  103,\n]",
-            format!("{:?}", arrow_batch.column(0)));
-        assert_eq!(
-            "PrimitiveArray<Float64>\n[\n  92.1,\n  93.2,\n  95.3,\n  96.4,\n  98.5,\n  99.6,\n  100.7,\n  101.8,\n]",
-            format!("{:?}", arrow_batch.column(1)));
-        assert_eq!(
-            "StringArray\n[\n  \"a\",\n  \"a\",\n  \"a\",\n  \"b\",\n  \"b\",\n  \"b\",\n  \"c\",\n  \"c\",\n]",
-            format!("{:?}", arrow_batch.column(2)));
-
+        let arrow_batch =
+            arrow_flight::utils::flight_data_to_arrow_batch(&flight_data_de, schema).unwrap()?;
+        println!("arrow_batch: \n{:?}", arrow_batch);
         Ok(())
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is an example of lambda functions generated with physical plans. These files can be references of rust code generation. A readme is included.

Note that `CastExpr::new()` and Schema deserialization can work only after [https://github.com/DSLAM-UMD/arrow/pull/4](url) is merged.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
