### PR TITLE
fix: set the lambda runtime to 15 mins

### DIFF
--- a/bench/nexmark/main.rs
+++ b/bench/nexmark/main.rs
@@ -324,6 +324,7 @@ async fn create_lambda_function(ctx: &ExecutionContext) -> Result<String> {
                 role: lambda::role().await,
                 runtime: lambda::runtime(),
                 environment: lambda::environment(&ctx),
+                timeout: Some(900),
                 ..Default::default()
             })
             .await


### PR DESCRIPTION

## Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

## Rationale for this change

 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The default amount of time that Lambda allows a function to run is 3 seconds. The maximum allowed value is 900 seconds.


## What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->



By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the GNU Affero General Public License v3.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
