### PR TITLE
fix: use main branch for aws-lambda repo

### DIFF
--- a/flock-function/Cargo.toml
+++ b/flock-function/Cargo.toml
@@ -24,7 +24,7 @@ flock = { path = "../flock" }
 futures = "0.3.12"
 hashring = { git = "https://github.com/flock-lab/hashring-rs", branch = "flock" }
 itertools = "0.10.0"
-lambda_runtime = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "master" }
+lambda_runtime = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "main" }
 lazy_static = "1.4"
 log = "0.4.14"
 mimalloc = { version = "0.1", optional = true, default-features = false }

--- a/flock/Cargo.toml
+++ b/flock/Cargo.toml
@@ -31,7 +31,7 @@ humantime = "2.1.0"
 indoc = "1.0.3"
 itertools = "0.10.0"
 json = "0.12.4"
-lambda_runtime = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "master" }
+lambda_runtime = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "main" }
 lazy_static = "1.4"
 log = "0.4.14"
 lz4 = "1.23.1"

--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -21,7 +21,7 @@ flock = { path = "../flock" }
 futures = "0.3.12"
 indoc = "1.0.3"
 itertools = "0.10.0"
-lambda_runtime = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "master" }
+lambda_runtime = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "main" }
 lazy_static = "1.4"
 log = "0.4.14"
 mimalloc = { version = "0.1", optional = true, default-features = false }


### PR DESCRIPTION

Cargo build failed due to the incorrect branch for aws-lambda repo, fixed. 
